### PR TITLE
Fix cancel query

### DIFF
--- a/src/QueryWindow.vala
+++ b/src/QueryWindow.vala
@@ -33,6 +33,11 @@ namespace Peeq {
       );
     }
 
+    ~QueryWindow () {
+      print("Destroy()");
+      connection.cancel ();
+    }
+
     public QueryWindow.with_conninfo (Peeq.Application application, string conninfo) {
       this.application = application;
       this.conninfo = conninfo;

--- a/src/Services/Connection.vala
+++ b/src/Services/Connection.vala
@@ -66,6 +66,11 @@ namespace Peeq.Services {
     Database database;
     int index = 0;
 
+    public void cancel () {
+      int result = database.request_cancel ();
+      GLib.print(@"result = $(result)");
+    }
+
     void start_working () {
       timer = new Timer ();
       this.working = true;

--- a/src/Services/Connection.vala
+++ b/src/Services/Connection.vala
@@ -67,8 +67,7 @@ namespace Peeq.Services {
     int index = 0;
 
     public void cancel () {
-      int result = database.request_cancel ();
-      GLib.print(@"result = $(result)");
+      database.request_cancel ();
     }
 
     void start_working () {
@@ -85,6 +84,10 @@ namespace Peeq.Services {
 
     public Connection.with_conninfo (string conninfo) {
       this.conninfo = conninfo;
+    }
+
+    public Connection duplicate () {
+      return new Connection.with_conninfo (this.conninfo);
     }
 
     public void connect_start () {

--- a/src/Utils/StyleManager.vala
+++ b/src/Utils/StyleManager.vala
@@ -31,7 +31,7 @@ namespace Peeq.Utils {
 
       try {
         var data = @"* {font-family: \"$(get_font_family ())\"; font-size: $(get_font_size ())pt; }";
-        print(@"$(data)\n");
+
         style.load_from_data (data, -1);
 
       } catch (GLib.Error e) {

--- a/src/Widgets/QueryHeaderBar.vala
+++ b/src/Widgets/QueryHeaderBar.vala
@@ -20,6 +20,7 @@
 namespace Peeq.Widgets { 
   public class QueryHeaderBar : Gtk.HeaderBar {
     public signal void execute_query ();
+    public signal void cancel_query ();
     public signal void open_file ();
 
     Gtk.Spinner spinner;
@@ -89,14 +90,14 @@ namespace Peeq.Widgets {
       cancel_button.tooltip_text = ("Cancel");
       cancel_button.set_sensitive (false);
       cancel_button.clicked.connect (() => {
-        execute_query();
+        cancel_query();
       });
 
       pack_start (open_button);
       pack_start (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
       pack_start (execute_button);
-//      pack_start (cancel_button);
-//      pack_start (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
+      pack_start (cancel_button);
+      pack_start (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
 //      pack_start (save_button);
 //      pack_start (save_as_button);
 

--- a/src/Widgets/QueryPaned.vala
+++ b/src/Widgets/QueryPaned.vala
@@ -25,16 +25,17 @@ namespace Peeq.Widgets {
   public class QueryPaned : Gtk.Box {
     public signal void is_working (bool working);
 
+    public QueryCommand query_command;
+    
     Granite.Widgets.CollapsiblePaned paned;
     SQLSourceView sql_source_view;
     ResultView result_view;
-    QueryCommand query_command;
     ClipboardManager clipboard_manager;
     ActionBar action_bar;
     Label status_label;
 
-    public QueryPaned.with_query_command (QueryCommand query_command) {
-      this.query_command = query_command;
+    public QueryPaned.with_conninfo (string conninfo) {
+      this.query_command = new QueryCommand.with_conninfo (conninfo);
       
       this.query_command.error.connect ((message) => {
         //print(@"$(message)\n");
@@ -87,6 +88,10 @@ namespace Peeq.Widgets {
     public void execute_query () {
       status_label.label = @"Running...";
       query_command.execute (sql_source_view.get_sql ());
+    }
+
+    public void cancel_query () {
+      query_command.cancel ();
     }
 
     public void set_text (string text) {


### PR DESCRIPTION
  * Enabled stop/cancel query headerbar button
  * Create a new connection per query pane
  * Correctly cancel and destroy connection
  * Managed working spinner indicator with multiple connections